### PR TITLE
Add target blank and noopener noreferrer to links

### DIFF
--- a/web/templates/_nav.html
+++ b/web/templates/_nav.html
@@ -23,10 +23,10 @@
         </a>
 {#        <a href="/announcements" class="nav-item">Announcements</a>#}
         <a href="/about" class="nav-item">About</a>
-        <a href="/github" target="_blank" class="nav-item">GitHub</a>
-        <a href="/matrix" target="_blank" class="nav-item">Matrix</a>
-        <a href="/discord" target="_blank" class="nav-item">Discord</a>
-{#        <a href="/calendar" target="_blank" class="nav-item">Calendar</a>#}
+        <a href="/github" target="_blank" rel="noopener noreferrer" class="nav-item">GitHub</a>
+        <a href="/matrix" target="_blank" rel="noopener noreferrer" class="nav-item">Matrix</a>
+        <a href="/discord" target="_blank" rel="noopener noreferrer" class="nav-item">Discord</a>
+{#        <a href="/calendar" target="_blank" rel="noopener noreferrer" class="nav-item">Calendar</a>#}
 	</div>
     <div class="page">
 	    <div>{% block content %}{% endblock %}</div>

--- a/web/templates/_nav.html
+++ b/web/templates/_nav.html
@@ -23,10 +23,10 @@
         </a>
 {#        <a href="/announcements" class="nav-item">Announcements</a>#}
         <a href="/about" class="nav-item">About</a>
-        <a href="/github" class="nav-item">GitHub</a>
-        <a href="/matrix" class="nav-item">Matrix</a>
-        <a href="/discord" class="nav-item">Discord</a>
-{#        <a href="/calendar" class="nav-item">Calendar</a>#}
+        <a href="/github" target="_blank" class="nav-item">GitHub</a>
+        <a href="/matrix" target="_blank" class="nav-item">Matrix</a>
+        <a href="/discord" target="_blank" class="nav-item">Discord</a>
+{#        <a href="/calendar" target="_blank" class="nav-item">Calendar</a>#}
 	</div>
     <div class="page">
 	    <div>{% block content %}{% endblock %}</div>

--- a/web/templates/about.html
+++ b/web/templates/about.html
@@ -7,7 +7,7 @@
     <h2>Software</h2>
     <div class="program-list">
     {% for program in software %}
-        <a class="program-link" target="_blank" href="{{ program.url }}">
+        <a class="program-link" target="_blank" rel="noopener noreferrer" href="{{ program.url }}">
             <img src="{{ program.icon }}">
             <p>{{ program.name }}</p>
         </a> 

--- a/web/templates/about.html
+++ b/web/templates/about.html
@@ -7,7 +7,7 @@
     <h2>Software</h2>
     <div class="program-list">
     {% for program in software %}
-        <a class="program-link" href="{{ program.url }}">
+        <a class="program-link" target="_blank" href="{{ program.url }}">
             <img src="{{ program.icon }}">
             <p>{{ program.name }}</p>
         </a> 

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -13,7 +13,7 @@
 		<h2>Learn More</h2>
 		<p>
         To learn more, visit the <a href="/about/">About</a> page or 
-        check out our <a href="/github" target="_blank">GitHub</a> page to view our 
+        check out our <a href="/github" target="_blank" rel="noopener noreferrer">GitHub</a> page to view our 
         active projects!
 		</p>
 	</div>

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -13,7 +13,7 @@
 		<h2>Learn More</h2>
 		<p>
         To learn more, visit the <a href="/about/">About</a> page or 
-        check out our <a href="/github">GitHub</a> page to view our 
+        check out our <a href="/github" target="_blank">GitHub</a> page to view our 
         active projects!
 		</p>
 	</div>


### PR DESCRIPTION
Links on the website currently navigate to other pages with the same tab when clicked. My changes make them navigate to linked pages with a new tab instead. 
With the exception of the "Home" and "About" buttons. Those link to pages hosted by the same server, so they do not need that feature.